### PR TITLE
Added Concrete Color Definitions for Template Tags and Code Blocks

### DIFF
--- a/custom_dark_theme.css
+++ b/custom_dark_theme.css
@@ -240,7 +240,7 @@ dl.reflist {
 /*********************************************/
 div.line {
 	background: transparent;
-	color: inherit;
+	color: #d7d7d7;
 }
 
 div.line a {
@@ -309,6 +309,10 @@ span.lineno a {
 .memTemplItemLeft, .memTemplItemRight, .memTemplParams {
 	background: #32363d;
 	color: inherit;
+}
+
+.memtemplate {
+	color: #B4CCF9;
 }
 
 .memSeparator {


### PR DESCRIPTION
Doxygen generated my code lines and template tags really dark. Defining concrete color codes seemed helped a lot.

Before:
![image](https://user-images.githubusercontent.com/16086309/90568488-f40ce680-e179-11ea-8451-17af07e3bd59.png)

After:
![image](https://user-images.githubusercontent.com/16086309/90568537-16066900-e17a-11ea-84b4-ebe544f3518e.png)
