### PR TITLE
Fix footer for svg logo

### DIFF
--- a/html_footer.html
+++ b/html_footer.html
@@ -5,7 +5,8 @@
 				$navpath
 				<li class="footer">
 					Generated on $datetime for $projectname by <a href="http://www.doxygen.org/index.html">
-					<img class="footer" src="$relpath$doxygen.png" alt="doxygen"/></a> $doxygenversion.
+					<img class="footer" src="$relpath$doxygen.png" alt="doxygen"
+                     onerror="this.onerror=null;this.src='$relpath$doxygen.svg';"/></a> $doxygenversion.
 					Dark theme by <a href="http://majerle.eu" target="_new">Tilen Majerle</a>. All rights reserved.
 				</li>
 			</ul>


### PR DESCRIPTION
Doxygen 1.18.19 switched the footer logo from a png to svg. Using this or later version results in missing logo in footer. I propose this change which attempts to work for either case. I only tested that this resolves my issue when I am using doxygen 1.18.20, with Safari and Chrome on Mac. I didnt back test it with older doxygen or check any other browsers or platforms.